### PR TITLE
fix: redis connection for bullmq

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -13,6 +13,7 @@ import { BlockchainModule } from '#lib/blockchain/blockchain.module';
 import { QueueConstants } from '#lib/utils/queues';
 import { redisEventsToEventEmitter } from '#lib/utils/redis';
 import { EnqueueService } from '#lib/services/enqueue-request.service';
+import { Redis } from 'ioredis';
 import { AccountsController } from './controllers/accounts.controller';
 import { ApiController } from './controllers/api.controller';
 import { DelegationController } from './controllers/delegation.controller';
@@ -68,25 +69,9 @@ import { KeysService } from './services/keys.service';
     ),
     BullModule.forRootAsync({
       imports: [ConfigModule],
-      useFactory: (configService: ConfigService) => {
-        // Note: BullMQ doesn't honor a URL for the Redis connection, and
-        // JS URL doesn't parse 'redis://' as a valid protocol, so we fool
-        // it by changing the URL to use 'http://' in order to parse out
-        // the host, port, username, password, etc.
-        // We could pass REDIS_HOST, REDIS_PORT, etc, in the environment, but
-        // trying to keep the # of environment variables from proliferating
-        const url = new URL(configService.redisUrl.toString().replace(/^redis[s]*/, 'http'));
-        const { hostname, port, username, password, pathname } = url;
-        return {
-          connection: {
-            host: hostname || undefined,
-            port: port ? Number(port) : undefined,
-            username: username || undefined,
-            password: password || undefined,
-            db: pathname?.length > 1 ? Number(pathname.slice(1)) : undefined,
-          },
-        };
-      },
+      useFactory: (configService: ConfigService) => ({
+        connection: new Redis(configService.redisUrl.toString()),
+      }),
       inject: [ConfigService],
     }),
     BullModule.registerQueue(
@@ -96,11 +81,6 @@ import { KeysService } from './services/keys.service';
           removeOnComplete: 20,
           removeOnFail: false,
           attempts: 1,
-        },
-        // Configuring enableOfflineQueue: false will not queue jobs if the connection is lost.
-        // The REST API will return a 500 error if the connection is lost.
-        connection: {
-          enableOfflineQueue: false,
         },
       },
       {

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -60,25 +60,9 @@ import { TransactionPublisherService } from './transaction_publisher/publisher.s
     ),
     BullModule.forRootAsync({
       imports: [ConfigModule],
-      useFactory: (configService: ConfigService) => {
-        // Note: BullMQ doesn't honor a URL for the Redis connection, and
-        // JS URL doesn't parse 'redis://' as a valid protocol, so we fool
-        // it by changing the URL to use 'http://' in order to parse out
-        // the host, port, username, password, etc.
-        // We could pass REDIS_HOST, REDIS_PORT, etc, in the environment, but
-        // trying to keep the # of environment variables from proliferating
-        const url = new URL(configService.redisUrl.toString().replace(/^redis[s]*/, 'http'));
-        const { hostname, port, username, password, pathname } = url;
-        return {
-          connection: {
-            host: hostname || undefined,
-            port: port ? Number(port) : undefined,
-            username: username || undefined,
-            password: password || undefined,
-            db: pathname?.length > 1 ? Number(pathname.slice(1)) : undefined,
-          },
-        };
-      },
+      useFactory: (configService: ConfigService) => ({
+        connection: new Redis(configService.redisUrl.toString(), { maxRetriesPerRequest: null }),
+      }),
       inject: [ConfigService],
     }),
     BullModule.registerQueue(


### PR DESCRIPTION
This PR instantiates a Redis connection specifically for BullMQ using the `REDIS_URL` instead of relying on `{ host, port }` parameters.