### PR TITLE
feat: rework chain scan for completed transactions

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -107,15 +107,7 @@ import { HealthController } from './controllers/health.controller';
     }),
     ScheduleModule.forRoot(),
   ],
-  providers: [
-    ApiService,
-    AccountsService,
-    HandlesService,
-    DelegationService,
-    KeysService,
-    ConfigService,
-    EnqueueService,
-  ],
+  providers: [ApiService, AccountsService, HandlesService, DelegationService, KeysService, EnqueueService],
   // Controller order determines the order of display for docs
   // v[Desc first][ABC Second], Health, and then Dev only last
   controllers: [AccountsControllerV1, DelegationControllerV1, HandlesControllerV1, KeysControllerV1, HealthController],

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -87,5 +87,5 @@ async function bootstrap() {
 }
 
 bootstrap().catch((err) => {
-  logger.error('Unhandled exception in boostrap', err);
+  logger.error('Unhandled exception in bootstrap', err, err?.stack);
 });

--- a/apps/worker/src/transaction_notifier/notifier.module.ts
+++ b/apps/worker/src/transaction_notifier/notifier.module.ts
@@ -1,10 +1,8 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { BlockchainModule } from '#lib/blockchain/blockchain.module';
-import { BlockchainService } from '#lib/blockchain/blockchain.service';
 import { QueueConstants } from '#lib/utils/queues';
 import { ConfigModule } from '#lib/config/config.module';
-import { ConfigService } from '#lib/config/config.service';
 import { EnqueueService } from '#lib/services/enqueue-request.service';
 import { TxnNotifierService } from './notifier.service';
 
@@ -31,7 +29,7 @@ import { TxnNotifierService } from './notifier.service';
       },
     ),
   ],
-  providers: [TxnNotifierService, BlockchainService, EnqueueService, ConfigService],
-  exports: [TxnNotifierService, BlockchainService, EnqueueService, ConfigService],
+  providers: [EnqueueService, TxnNotifierService],
+  exports: [EnqueueService, TxnNotifierService],
 })
 export class TxnNotifierModule {}

--- a/apps/worker/src/transaction_notifier/notifier.service.helper.createWebhookRsp.ts
+++ b/apps/worker/src/transaction_notifier/notifier.service.helper.createWebhookRsp.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-redeclare */
-import { Job } from 'bullmq';
 import {
   PublishHandleOpts,
   PublishHandleWebhookRsp,
@@ -7,26 +6,26 @@ import {
   PublishKeysWebhookRsp,
   SIWFOpts,
   SIWFWebhookRsp,
-  TxMonitorJob,
   TxWebhookOpts,
 } from '#lib/types/dtos/transaction.request.dto';
+import { ITxStatus } from '#lib/interfaces/tx-status.interface';
 
 export function createWebhookRsp(
-  job: Job<TxMonitorJob, any, string>,
+  txStatus: ITxStatus,
   msaId: string,
   options: PublishHandleOpts,
 ): PublishHandleWebhookRsp;
-export function createWebhookRsp(job: Job<TxMonitorJob, any, string>, msaId: string, options: SIWFOpts): SIWFWebhookRsp;
+export function createWebhookRsp(txStatus: ITxStatus, msaId: string, options: SIWFOpts): SIWFWebhookRsp;
+export function createWebhookRsp(txStatus: ITxStatus, msaId: string, options: PublishKeysOpts): PublishKeysWebhookRsp;
 export function createWebhookRsp(
-  job: Job<TxMonitorJob, any, string>,
+  { type: transactionType, providerId, referenceId }: ITxStatus,
   msaId: string,
-  options: PublishKeysOpts,
-): PublishKeysWebhookRsp;
-export function createWebhookRsp(job: Job<TxMonitorJob, any, string>, msaId: string, options: TxWebhookOpts): unknown {
+  options: TxWebhookOpts,
+): unknown {
   return {
-    transactionType: job.data.type,
-    providerId: job.data.providerId,
-    referenceId: job.data.referenceId,
+    transactionType,
+    providerId,
+    referenceId,
     msaId,
     ...options,
   };

--- a/apps/worker/src/transaction_notifier/notifier.service.ts
+++ b/apps/worker/src/transaction_notifier/notifier.service.ts
@@ -1,93 +1,161 @@
+/* eslint-disable no-await-in-loop */
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
-import { Processor } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
-import { Job } from 'bullmq';
+import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common';
 import Redis from 'ioredis';
 import { MILLISECONDS_PER_SECOND } from 'time-constants';
-import { IEventData, RegistryError } from '@polkadot/types/types';
 import axios from 'axios';
 import { BlockchainConstants } from '#lib/blockchain/blockchain-constants';
 import { BlockchainService } from '#lib/blockchain/blockchain.service';
 import { TransactionType } from '#lib/types/enums';
 import { QueueConstants } from '#lib/utils/queues';
-import { BaseConsumer } from '#worker/BaseConsumer';
-import { TxMonitorJob, SECONDS_PER_BLOCK, TxWebhookRsp } from 'libs/common/src';
-import { ConfigService } from '#lib/config/config.service';
+import { SECONDS_PER_BLOCK, TxWebhookRsp, RedisUtils } from 'libs/common/src';
 import { createWebhookRsp } from '#worker/transaction_notifier/notifier.service.helper.createWebhookRsp';
+import { BlockchainScannerService } from '#lib/utils/blockchain-scanner.service';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { BlockHash } from '@polkadot/types/interfaces';
+import { HexString } from '@polkadot/util/types';
+import { ITxStatus } from '#lib/interfaces/tx-status.interface';
+import { FrameSystemEventRecord } from '@polkadot/types/lookup';
+import { ConfigService } from '#lib/config/config.service';
 
 @Injectable()
-@Processor(QueueConstants.TRANSACTION_NOTIFY_QUEUE)
-export class TxnNotifierService extends BaseConsumer {
-  constructor(
-    @InjectRedis() private cacheManager: Redis,
-    private blockchainService: BlockchainService,
-    private configService: ConfigService,
-  ) {
-    super();
+export class TxnNotifierService
+  extends BlockchainScannerService
+  implements OnApplicationBootstrap, OnApplicationShutdown
+{
+  async onApplicationBootstrap() {
+    await this.blockchainService.isReady();
+    const pendingTxns = await this.cacheManager.hkeys(RedisUtils.TXN_WATCH_LIST_KEY);
+    // If no transactions pending, skip to end of chain at startup
+    if (pendingTxns.length === 0) {
+      const blockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      await this.setLastSeenBlockNumber(blockNumber);
+    }
+    this.schedulerRegistry.addInterval(
+      this.intervalName,
+      setInterval(() => this.scan(), BlockchainConstants.SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND),
+    );
   }
 
-  /**
-   * Processes a job for transaction notification.
-   *
-   * @param job - Search the finalized blocks for the transaction hash in TxMonitorJob.
-   * @returns A promise that resolves to the result of the processing.
-   * @throws If there is an error during the processing.
-   */
-  async process(job: Job<TxMonitorJob, any, string>): Promise<any> {
-    this.logger.log(`Processing job ${job.id} of type ${job.name}`);
+  async onApplicationShutdown(_signal?: string | undefined) {
+    if (this.schedulerRegistry.doesExist('interval', this.intervalName)) {
+      this.schedulerRegistry.deleteInterval(this.intervalName);
+    }
+  }
+
+  constructor(
+    blockchainService: BlockchainService,
+    private readonly schedulerRegistry: SchedulerRegistry,
+    @InjectRedis() cacheManager: Redis,
+    private readonly configService: ConfigService,
+  ) {
+    super(cacheManager, blockchainService, new Logger(TxnNotifierService.prototype.constructor.name));
+  }
+
+  public get intervalName() {
+    return `${this.constructor.name}:blockchainScan`;
+  }
+
+  private async setEpochCapacity(epoch: string | number, capacityWithdrawn: bigint): Promise<void> {
+    const epochCapacityKey = `epochCapacity:${epoch}`;
+
     try {
-      const numberBlocksToParse = BlockchainConstants.NUMBER_BLOCKS_TO_CRAWL;
-      const txCapacityEpoch = job.data.epoch;
-      const previousKnownBlockNumber = (
-        await this.blockchainService.getBlock(job.data.lastFinalizedBlockHash)
-      ).block.header.number.toBigInt();
-      const currentFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
-      const blockList: bigint[] = [];
+      const savedCapacity = await this.cacheManager.get(epochCapacityKey);
+      const epochCapacity = BigInt(savedCapacity ?? 0);
+      const newEpochCapacity = epochCapacity + capacityWithdrawn;
 
-      for (
-        let i = previousKnownBlockNumber;
-        i <= currentFinalizedBlockNumber && i < previousKnownBlockNumber + numberBlocksToParse;
-        i += 1n
-      ) {
-        blockList.push(i);
+      const epochDurationBlocks = await this.blockchainService.getCurrentEpochLength();
+      const epochDuration = epochDurationBlocks * SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND;
+      await this.cacheManager.setex(epochCapacityKey, epochDuration, newEpochCapacity.toString());
+    } catch (error) {
+      this.logger.error(`Error setting epoch capacity: ${error}`);
+    }
+  }
+
+  protected async checkInitialScanParameters(): Promise<boolean> {
+    const pendingTxns = await this.cacheManager.hlen(RedisUtils.TXN_WATCH_LIST_KEY);
+    return pendingTxns > 0;
+  }
+
+  protected async checkScanParameters(): Promise<boolean> {
+    const pendingTxns = await this.cacheManager.hlen(RedisUtils.TXN_WATCH_LIST_KEY);
+    return pendingTxns > 0;
+  }
+
+  public async getLastSeenBlockNumber(): Promise<number> {
+    let blockNumber = await super.getLastSeenBlockNumber();
+    const pendingTxns = await this.cacheManager.hvals(RedisUtils.TXN_WATCH_LIST_KEY);
+    if (pendingTxns.length > 0) {
+      const startingBlock = Math.min(
+        ...pendingTxns.map((valStr) => {
+          const val = JSON.parse(valStr) as ITxStatus;
+          return val.birth;
+        }),
+      );
+
+      blockNumber = Math.max(blockNumber, startingBlock);
+    }
+
+    return blockNumber;
+  }
+
+  async processCurrentBlock(currentBlockHash: BlockHash, currentBlockNumber: number): Promise<void> {
+    // Get set of tx hashes to monitor from cache
+    const pendingTxns = (await this.cacheManager.hvals(RedisUtils.TXN_WATCH_LIST_KEY)).map(
+      (val) => JSON.parse(val) as ITxStatus,
+    );
+
+    const block = await this.blockchainService.getBlock(currentBlockHash);
+    const extrinsicIndices: [HexString, number][] = [];
+    block.block.extrinsics.forEach((extrinsic, index) => {
+      if (pendingTxns.some(({ txHash }) => txHash === extrinsic.hash.toHex())) {
+        extrinsicIndices.push([extrinsic.hash.toHex(), index]);
       }
-      const txResult = await this.blockchainService.crawlBlockListForTx(job.data.txHash, blockList, [
-        { pallet: 'system', event: 'ExtrinsicSuccess' },
-      ]);
-      if (!txResult.found) {
-        const message = `Tx ${job.data.txHash} not found in block list`;
-        this.logger.error(message);
-        throw new Error(message);
-      } else {
-        // Set current epoch capacity
-        await this.setEpochCapacity(txCapacityEpoch, BigInt(txResult.capacityWithDrawn ?? 0n));
-        if (txResult.error) {
-          this.logger.debug(`Error found in tx result: ${JSON.stringify(txResult.error)}`);
-          const errorReport = await this.handleMessagesFailure(txResult.error);
-          if (errorReport.retry) {
-            // TODO: Determine if errors are recoverable and if we need to retry the job
-            // await this.retryRequestJob(job.data.referencePublishJob.referenceId);
-          } else {
-            throw new Error(`Job ${job.data.id} failed with error ${JSON.stringify(txResult.error)}`);
-          }
-        }
+    });
 
-        if (txResult.success) {
-          this.logger.verbose(`Successfully found ${job.data.txHash} found in block ${txResult.blockHash}`);
+    if (extrinsicIndices.length > 0) {
+      const at = await this.blockchainService.api.at(currentBlockHash);
+      const epoch = (await at.query.capacity.currentEpoch()).toNumber();
+      const events: FrameSystemEventRecord[] = (await at.query.system.events()).filter(
+        ({ phase }) => phase.isApplyExtrinsic && extrinsicIndices.some((index) => phase.asApplyExtrinsic.eq(index)),
+      );
+
+      const totalCapacityWithdrawn: bigint = events
+        .filter(({ event }) => at.events.capacity.CapacityWithdrawn.is(event))
+        .reduce((sum, { event }) => (event as unknown as any).data.amount.toBigInt() + sum, 0n);
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const [txHash, txIndex] of extrinsicIndices) {
+        const extrinsicEvents = events.filter(
+          ({ phase }) => phase.isApplyExtrinsic && phase.asApplyExtrinsic.eq(txIndex),
+        );
+        const txStatusStr = await this.cacheManager.hget(RedisUtils.TXN_WATCH_LIST_KEY, txHash);
+        const txStatus = JSON.parse(txStatusStr!) as ITxStatus;
+        const successEvent = extrinsicEvents.find(
+          ({ event }) =>
+            event.section === txStatus.successEvent.section && event.method === txStatus.successEvent.method,
+        )?.event;
+        const failureEvent = extrinsicEvents.find(({ event }) => at.events.system.ExtrinsicFailed.is(event))?.event;
+
+        // TODO: Should the webhook provide for reporting failure?
+        if (failureEvent && at.events.system.ExtrinsicFailed.is(failureEvent)) {
+          const { dispatchError } = failureEvent.data;
+          const moduleThatErrored = dispatchError.asModule;
+          const moduleError = dispatchError.registry.findMetaError(moduleThatErrored);
+          this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
+        } else if (successEvent) {
+          this.logger.verbose(`Successfully found transaction ${txHash} in block ${currentBlockHash}`);
           const webhook = await this.getWebhook();
           let webhookResponse: Partial<TxWebhookRsp> = {};
-          webhookResponse.referenceId = job.data.id;
+          webhookResponse.referenceId = txStatus.referenceId;
 
-          const jobType: TxMonitorJob['type'] = job.data.type;
-          switch (jobType) {
+          switch (txStatus.type) {
             case TransactionType.CHANGE_HANDLE:
             case TransactionType.CREATE_HANDLE:
-              if (!txResult.events) {
-                this.logger.error('No Handle events found in tx result');
-              } else {
-                const handleTxnValues = this.blockchainService.handlePublishHandleTxResult(txResult.events);
+              {
+                const handleTxnValues = this.blockchainService.handlePublishHandleTxResult(successEvent);
 
-                webhookResponse = createWebhookRsp(job, handleTxnValues.msaId, { handle: handleTxnValues.handle });
+                webhookResponse = createWebhookRsp(txStatus, handleTxnValues.msaId, { handle: handleTxnValues.handle });
 
                 this.logger.debug(handleTxnValues.debugMsg);
                 this.logger.log(
@@ -96,12 +164,10 @@ export class TxnNotifierService extends BaseConsumer {
               }
               break;
             case TransactionType.SIWF_SIGNUP:
-              if (!txResult.events) {
-                this.logger.error('No SIWF events found in tx result');
-              } else {
-                const siwfTxnValues = this.blockchainService.handleSIWFTxnResult(txResult.events);
+              {
+                const siwfTxnValues = this.blockchainService.handleSIWFTxnResult(extrinsicEvents);
 
-                webhookResponse = createWebhookRsp(job, siwfTxnValues.msaId, {
+                webhookResponse = createWebhookRsp(txStatus, siwfTxnValues.msaId, {
                   accountId: siwfTxnValues.address,
                   handle: siwfTxnValues.handle,
                 });
@@ -112,12 +178,10 @@ export class TxnNotifierService extends BaseConsumer {
               }
               break;
             case TransactionType.ADD_KEY:
-              if (!txResult.events) {
-                this.logger.error('No ADD KEY events found in tx result');
-              } else {
-                const publicKeyValues = this.blockchainService.handlePublishKeyTxResult(txResult.events);
+              {
+                const publicKeyValues = this.blockchainService.handlePublishKeyTxResult(successEvent);
 
-                webhookResponse = createWebhookRsp(job, publicKeyValues.msaId, {
+                webhookResponse = createWebhookRsp(txStatus, publicKeyValues.msaId, {
                   newPublicKey: publicKeyValues.newPublicKey,
                 });
 
@@ -128,7 +192,7 @@ export class TxnNotifierService extends BaseConsumer {
               }
               break;
             default:
-              this.logger.error(`Unknown transaction type on job.data: ${jobType}`);
+              this.logger.error(`Unknown transaction type on job.data: ${txStatus.type}`);
               break;
           }
 
@@ -137,7 +201,6 @@ export class TxnNotifierService extends BaseConsumer {
             try {
               this.logger.debug(`Sending transaction notification to webhook: ${webhook}`);
               this.logger.debug(`Transaction: ${JSON.stringify(webhookResponse)}`);
-              // eslint-disable-next-line no-await-in-loop
               await axios.post(webhook, webhookResponse);
               this.logger.debug(`Transaction Notification sent to webhook: ${webhook}`);
               break;
@@ -147,80 +210,28 @@ export class TxnNotifierService extends BaseConsumer {
               retries += 1;
             }
           }
+        } else {
+          this.logger.error(`Watched transaction ${txHash} found, but neither success nor error???`);
         }
+
+        await this.cacheManager.hdel(RedisUtils.TXN_WATCH_LIST_KEY, txHash); // Remove txn from watch list
+        const idx = pendingTxns.findIndex((value) => value.txHash === txHash);
+        pendingTxns.slice(idx, 1);
       }
-    } catch (e) {
-      this.logger.error(e);
-      throw e;
+
+      await this.setEpochCapacity(epoch, totalCapacityWithdrawn);
     }
-  }
 
-  // TODO: Determine if any errors are recoverable and if we need to retry the job
-  //       The queue will automatically retry the job if it fails already.
-
-  // private async retryRequestJob(requestReferenceId: string): Promise<void> {
-  //   this.logger.debug(`Retrying graph change request job ${requestReferenceId}`);
-  //   const requestJob: Job<ProviderGraphUpdateJob, any, string> | undefined =
-  //     await this.changeRequestQueue.getJob(requestReferenceId);
-  //   if (!requestJob) {
-  //     this.logger.debug(`Job ${requestReferenceId} not found in queue`);
-  //     return;
-  //   }
-  //   await this.changeRequestQueue.remove(requestReferenceId);
-  //   await this.changeRequestQueue.add(
-  //     `Retrying publish job - ${requestReferenceId}`,
-  //     requestJob.data,
-  //     {
-  //       jobId: requestReferenceId,
-  //     },
-  //   );
-  // }
-
-  private async setEpochCapacity(epoch: string, capacityWithdrew: bigint): Promise<void> {
-    const epochCapacityKey = `epochCapacity:${epoch}`;
-
-    try {
-      const savedCapacity = await this.cacheManager.get(epochCapacityKey);
-      const epochCapacity = BigInt(savedCapacity ?? 0);
-      const newEpochCapacity = epochCapacity + capacityWithdrew;
-
-      const epochDurationBlocks = await this.blockchainService.getCurrentEpochLength();
-      const epochDuration = epochDurationBlocks * SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND;
-      await this.cacheManager.setex(epochCapacityKey, epochDuration, newEpochCapacity.toString());
-    } catch (error) {
-      this.logger.error(`Error setting epoch capacity: ${error}`);
-    }
-  }
-
-  private async handleMessagesFailure(moduleError: RegistryError): Promise<{ pause: boolean; retry: boolean }> {
-    try {
-      // Handle the possible errors for create_sponsored_account_with_delegation and grant_delegation from the msa pallet
-      this.logger.debug(`Handling module error: ${moduleError?.method}`);
-      switch (moduleError.method) {
-        case 'AddProviderSignatureVerificationFailed':
-        case 'DuplicateProvider':
-        case 'UnauthorizedProvider':
-        case 'InvalidSelfProvider':
-        case 'InvalidSignature':
-        case 'NoKeyExists':
-        case 'KeyAlreadyRegistered':
-        case 'ProviderNotRegistered':
-        case 'ProofNotYetValid':
-        case 'ProofHasExpired':
-        case 'SignatureAlreadySubmitted':
-        case 'UnauthorizedDelegator':
-          // TODO: Are any of these errors recoverable?
-          return { pause: false, retry: false };
-        default:
-          this.logger.error(`Unknown module error ${moduleError}`);
-          break;
+    // Now check all pending transactions for expiration as of this block
+    // eslint-disable-next-line no-restricted-syntax
+    for (const txStatus of pendingTxns) {
+      if (txStatus.death <= currentBlockNumber) {
+        this.logger.verbose(
+          `Tx ${txStatus.txHash} expired (birth: ${txStatus.birth}, death: ${txStatus.death}, currentBlock: ${currentBlockNumber})`,
+        );
+        await this.cacheManager.hdel(RedisUtils.TXN_WATCH_LIST_KEY, txStatus.txHash);
       }
-    } catch (error) {
-      this.logger.error(`Error handling module error: ${error}`);
     }
-
-    // unknown error, pause the queue
-    return { pause: false, retry: false };
   }
 
   async getWebhookList(msaId: number): Promise<string[]> {

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { ScheduleModule } from '@nestjs/schedule';
 import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
-import { DEFAULT_REDIS_NAMESPACE, RedisModule, getRedisToken } from '@liaoliaots/nestjs-redis';
+import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { Redis } from 'ioredis';
 import { BlockchainModule } from '#lib/blockchain/blockchain.module';
 import { NonceService } from '#lib/services/nonce.service';
@@ -13,9 +13,7 @@ import { ConfigModule } from '#lib/config/config.module';
 import { ConfigService } from '#lib/config/config.service';
 import { redisEventsToEventEmitter } from '#lib/utils/redis';
 import { TxnNotifierModule } from './transaction_notifier/notifier.module';
-import { TxnNotifierService } from './transaction_notifier/notifier.service';
 import { TransactionPublisherModule } from './transaction_publisher/publisher.module';
-import { TransactionPublisherService } from './transaction_publisher/publisher.service';
 
 @Module({
   imports: [
@@ -88,7 +86,7 @@ import { TransactionPublisherService } from './transaction_publisher/publisher.s
     TransactionPublisherModule,
     TxnNotifierModule,
   ],
-  providers: [ConfigService, TransactionPublisherService, TxnNotifierService, ProviderWebhookService, NonceService],
+  providers: [ProviderWebhookService, NonceService],
   exports: [],
 })
 export class WorkerModule {}

--- a/libs/common/src/blockchain/blockchain-constants.ts
+++ b/libs/common/src/blockchain/blockchain-constants.ts
@@ -29,6 +29,8 @@ export namespace BlockchainConstants {
     extrinsic: EX_PAY_CAPACITY_BATCH,
   };
 
+  export const SECONDS_PER_BLOCK = 12;
+
   /**
    * The number of blocks to crawl for a given job
    * @type {number}

--- a/libs/common/src/blockchain/blockchain.service.ts
+++ b/libs/common/src/blockchain/blockchain.service.ts
@@ -1,13 +1,12 @@
 /* eslint-disable no-underscore-dangle */
 import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common';
 import { options } from '@frequency-chain/api-augment';
-import { ApiPromise, ApiRx, HttpProvider, WsProvider } from '@polkadot/api';
-import { firstValueFrom } from 'rxjs';
+import { ApiPromise, HttpProvider, WsProvider } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { BlockHash, BlockNumber, DispatchError, EventRecord, Hash, SignedBlock } from '@polkadot/types/interfaces';
+import { BlockHash, BlockNumber, Event, SignedBlock } from '@polkadot/types/interfaces';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { AnyNumber, ISubmittableResult, RegistryError } from '@polkadot/types/types';
-import { u32, Option, u128, Bytes, Vec } from '@polkadot/types';
+import { AnyNumber, ISubmittableResult } from '@polkadot/types/types';
+import { u32, Option, Bytes } from '@polkadot/types';
 import {
   CommonPrimitivesHandlesClaimHandlePayload,
   CommonPrimitivesMsaDelegation,
@@ -48,9 +47,7 @@ interface PublicKeyValues {
 
 @Injectable()
 export class BlockchainService implements OnApplicationBootstrap, OnApplicationShutdown {
-  public api: ApiRx;
-
-  public apiPromise: ApiPromise;
+  public api: ApiPromise;
 
   private configService: ConfigService;
 
@@ -67,30 +64,24 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
       this.logger.error(`Unrecognized chain URL type: ${providerUrl.toString()}`);
       throw new Error('Unrecognized chain URL type');
     }
-    this.api = await firstValueFrom(ApiRx.create({ provider, ...options }));
-    this.apiPromise = await ApiPromise.create({ provider, ...options });
-    await Promise.all([firstValueFrom(this.api.isReady), this.apiPromise.isReady]);
+    this.api = await ApiPromise.create({ provider, ...options }).then((api) => api.isReady);
     this.logger.log('Blockchain API ready.');
   }
 
   public async isReady(): Promise<boolean> {
-    await this.apiPromise.isReady;
+    await this.api?.isReady;
     return true;
   }
 
   public async getApi(): Promise<ApiPromise> {
-    await this.apiPromise.isReady;
-    return this.apiPromise;
+    await this.api.isReady;
+    return this.api;
   }
 
-  public async onApplicationShutdown(signal?: string | undefined) {
+  public async onApplicationShutdown(_signal?: string | undefined) {
     const promises: Promise<any>[] = [];
     if (this.api) {
       promises.push(this.api.disconnect());
-    }
-
-    if (this.apiPromise) {
-      promises.push(this.apiPromise.disconnect());
     }
     await Promise.all(promises);
   }
@@ -101,23 +92,23 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
   }
 
   public getBlockHash(block: BlockNumber | AnyNumber): Promise<BlockHash> {
-    return firstValueFrom(this.api.rpc.chain.getBlockHash(block));
+    return this.api.rpc.chain.getBlockHash(block);
   }
 
   public getBlock(block: BlockHash): Promise<SignedBlock> {
-    return firstValueFrom(this.api.rpc.chain.getBlock(block));
+    return this.api.rpc.chain.getBlock(block);
   }
 
   public async getLatestFinalizedBlockHash(): Promise<BlockHash> {
-    return (await this.apiPromise.rpc.chain.getFinalizedHead()) as BlockHash;
+    return (await this.api.rpc.chain.getFinalizedHead()) as BlockHash;
   }
 
-  public async getLatestFinalizedBlockNumber(): Promise<bigint> {
-    return (await this.apiPromise.rpc.chain.getBlock()).block.header.number.toBigInt();
+  public async getLatestFinalizedBlockNumber(): Promise<number> {
+    return (await this.api.rpc.chain.getBlock()).block.header.number.toNumber();
   }
 
   public async getBlockNumberForHash(hash: string): Promise<number | undefined> {
-    const block = await this.apiPromise.rpc.chain.getBlock(hash);
+    const block = await this.api.rpc.chain.getBlock(hash);
     if (block) {
       return block.block.header.number.toNumber();
     }
@@ -133,26 +124,24 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
   public createExtrinsicCall(
     { pallet, extrinsic }: { pallet: string; extrinsic: string },
     ...args: (any | undefined)[]
-  ): SubmittableExtrinsic<'rxjs', ISubmittableResult> {
+  ): SubmittableExtrinsic<'promise', ISubmittableResult> {
     return this.api.tx[pallet][extrinsic](...args);
   }
 
   public createExtrinsic(
     { pallet, extrinsic }: { pallet: string; extrinsic: string },
-    { eventPallet, event }: { eventPallet?: string; event?: string },
     keys: KeyringPair,
     ...args: (any | undefined)[]
   ): Extrinsic {
-    const targetEvent = eventPallet && event ? this.api.events[eventPallet][event] : undefined;
-    return new Extrinsic(this.api, this.api.tx[pallet][extrinsic](...args), keys, targetEvent);
+    return new Extrinsic(this.api, this.api.tx[pallet][extrinsic](...args), keys);
   }
 
   public rpc(pallet: string, rpc: string, ...args: (any | undefined)[]): Promise<any> {
-    return this.apiPromise.rpc[pallet][rpc](...args);
+    return this.api.rpc[pallet][rpc](...args);
   }
 
   public query(pallet: string, extrinsic: string, ...args: (any | undefined)[]): Promise<any> {
-    return args ? this.apiPromise.query[pallet][extrinsic](...args) : this.apiPromise.query[pallet][extrinsic]();
+    return args ? this.api.query[pallet][extrinsic](...args) : this.api.query[pallet][extrinsic]();
   }
 
   public async queryAt(
@@ -161,7 +150,7 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     extrinsic: string,
     ...args: (any | undefined)[]
   ): Promise<any> {
-    const newApi = await this.apiPromise.at(blockHash);
+    const newApi = await this.api.at(blockHash);
     return newApi.query[pallet][extrinsic](...args);
   }
 
@@ -196,10 +185,9 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
   }
 
   public async getKeysByMsa(msaId: string): Promise<KeyInfoResponse> {
-    const keyInfoResponse = this.api.rpc.msa.getKeysByMsaId(msaId);
-    const value = await firstValueFrom(keyInfoResponse);
-    if (value.isSome) {
-      return value.unwrap();
+    const keyInfoResponse = await this.api.rpc.msa.getKeysByMsaId(msaId);
+    if (keyInfoResponse.isSome) {
+      return keyInfoResponse.unwrap();
     }
     throw new Error(`No keys found for msaId: ${msaId}`);
   }
@@ -262,7 +250,7 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     msaId: AnyNumber,
     providerId: AnyNumber,
   ): Promise<CommonPrimitivesMsaDelegation | null> {
-    const delegationResponse = await this.apiPromise.query.msa.delegatorAndProviderToDelegation(msaId, providerId);
+    const delegationResponse = await this.api.query.msa.delegatorAndProviderToDelegation(msaId, providerId);
     if (delegationResponse.isSome) return delegationResponse.unwrap();
     return null;
   }
@@ -328,121 +316,12 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     return typeof epochLength === 'number' ? epochLength : epochLength.toNumber();
   }
 
-  public async crawlBlockListForTx(
-    txHash: Hash,
-    blockList: bigint[],
-    successEvents: [{ pallet: string; event: string }],
-  ): Promise<{
-    found: boolean;
-    success: boolean;
-    blockHash?: BlockHash;
-    capacityWithDrawn?: string;
-    error?: RegistryError;
-    events?: Vec<FrameSystemEventRecord>;
-  }> {
-    const txReceiptPromises: Promise<{
-      found: boolean;
-      success: boolean;
-      blockHash?: BlockHash;
-      capacityWithDrawn?: string;
-      error?: RegistryError;
-      events?: Vec<FrameSystemEventRecord>;
-    }>[] = blockList.map(async (blockNumber) => {
-      const blockHash = await this.getBlockHash(blockNumber);
-      const block = await this.getBlock(blockHash);
-      const txInfo = block.block.extrinsics.find((extrinsic) => extrinsic.hash.toString() === txHash.toString());
-
-      if (!txInfo) {
-        return { found: false, success: false };
-      }
-
-      this.logger.verbose(`Found tx ${txHash} in block ${blockNumber}`);
-      const at = await this.api.at(blockHash.toHex());
-      const eventsPromise = firstValueFrom(at.query.system.events());
-
-      let isTxSuccess = false;
-      let totalBlockCapacity: bigint = 0n;
-      let txError: RegistryError | undefined;
-      const events = await eventsPromise;
-
-      try {
-        events.forEach((record) => {
-          const { event } = record;
-          const eventName = event.section;
-          const { method, data } = event;
-          this.logger.debug(`Received event: ${eventName} ${method} ${data}`);
-
-          if (record.event && this.api.events.capacity.CapacityWithdrawn.is(record.event)) {
-            const currentCapacity: u128 = record.event.data.amount;
-            totalBlockCapacity += currentCapacity.toBigInt();
-          }
-
-          // SIWF Events:
-          //   MsaCreated
-          //   MsaDelegated
-          //   HandleClaimed
-          if (
-            eventName.search('msa') !== -1 &&
-            (method.search('MsaCreated') !== -1 || method.search('MsaDelegated') !== -1)
-          ) {
-            events.push(record);
-          }
-
-          // Handle Events:
-          //   HandleClaimed
-          if (eventName.search('handles') !== -1 && method.search('HandleClaimed') !== -1) {
-            events.push(record);
-          }
-
-          // Key Events:
-          //   KeyAdded
-          if (eventName.search('msa') !== -1 && method.search('PublicKeyAdded') !== -1) {
-            events.push(record);
-          }
-
-          // check custom success events
-          if (
-            successEvents.find((successEvent) => successEvent.pallet === eventName && successEvent.event === method)
-          ) {
-            this.logger.debug(`Found success event ${eventName} ${method}`);
-            isTxSuccess = true;
-          }
-
-          // check for system extrinsic failure
-          // TODO: ???refactor to use the api.events.system.ExtrinsicFailed.is(record.event)
-          if (eventName.search('system') !== -1 && method.search('ExtrinsicFailed') !== -1) {
-            const dispatchError = data[0] as DispatchError;
-            const moduleThatErrored = dispatchError.asModule;
-            const moduleError = dispatchError.registry.findMetaError(moduleThatErrored);
-            txError = moduleError;
-            this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
-          }
-        });
-      } catch (error) {
-        this.logger.error(error);
-      }
-      this.logger.debug(`Total capacity withdrawn in block: ${totalBlockCapacity.toString()}`);
-      return {
-        found: true,
-        success: isTxSuccess,
-        blockHash,
-        capacityWithDrawn: totalBlockCapacity.toString(),
-        error: txError,
-        events,
-      };
-    });
-    const results = await Promise.all(txReceiptPromises);
-    const result = results.find((receipt) => receipt.found);
-    this.logger.debug(`Found tx receipt: ${JSON.stringify(result)}`);
-    return result ?? { found: false, success: false };
-  }
-
   /**
    * Handles the result of a SIWF transaction by extracting relevant values from the transaction events.
    * @param txResultEvents - The transaction result events to process.
    * @returns An object containing the extracted SIWF transaction values.
    */
-  public handleSIWFTxnResult = (txResultEvents: Vec<EventRecord>): SIWFTxnValues => {
+  public handleSIWFTxnResult(txResultEvents: FrameSystemEventRecord[]): SIWFTxnValues {
     const siwfTxnValues: Partial<SIWFTxnValues> = {};
 
     txResultEvents.forEach((record) => {
@@ -464,43 +343,43 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
       }
     });
     return siwfTxnValues as SIWFTxnValues;
-  };
+  }
 
   /**
    * Handles the publish handle transaction result events and extracts the handle and msaId from the event data.
-   * @param txResultEvents - The transaction result events to handle.
+   * @param event - The HandleClaimed event
    * @returns An object containing the extracted handle, msaId, and debug message.
    */
-  public handlePublishHandleTxResult = (txResultEvents: Vec<EventRecord>): HandleTxnValues => {
+  public handlePublishHandleTxResult(event: Event): HandleTxnValues {
     const handleTxnValues: Partial<HandleTxnValues> = {};
 
-    txResultEvents.forEach((record) => {
-      // Grab the handle and msa id from the event data
-      if (record.event && this.api.events.handles.HandleClaimed.is(record.event)) {
-        const handleHex = record.event.data.handle.toString();
-        // Remove the 0x prefix from the handle and convert the hex handle to a utf-8 string
-        const handleData = handleHex.slice(2);
-        handleTxnValues.handle = Buffer.from(handleData.toString(), 'hex').toString('utf-8');
-        handleTxnValues.msaId = record.event.data.msaId.toString();
-        handleTxnValues.debugMsg = `Handle created: ${handleTxnValues.handle} for msaId: ${handleTxnValues.msaId}`;
-      }
-    });
+    if (this.api.events.handles.HandleClaimed.is(event)) {
+      const handleHex = event.data.handle.toString();
+      // Remove the 0x prefix from the handle and convert the hex handle to a utf-8 string
+      const handleData = handleHex.slice(2);
+      handleTxnValues.handle = Buffer.from(handleData.toString(), 'hex').toString('utf-8');
+      handleTxnValues.msaId = event.data.msaId.toString();
+      handleTxnValues.debugMsg = `Handle created: ${handleTxnValues.handle} for msaId: ${handleTxnValues.msaId}`;
+    }
 
     return handleTxnValues as HandleTxnValues;
-  };
+  }
 
-  public handlePublishKeyTxResult = (txResultEvents: Vec<EventRecord>): PublicKeyValues => {
+  /**
+   * Description
+   * @param {Event} event - The PublicKeyAdded event
+   * @returns {PublicKeyValuesy} An object containing the MSA ID & new public key
+   */
+  public handlePublishKeyTxResult(event: Event): PublicKeyValues {
     const publicKeyValues: Partial<PublicKeyValues> = {};
 
-    txResultEvents.forEach((record) => {
-      // Grab the event data
-      if (record.event && this.api.events.msa.PublicKeyAdded.is(record.event)) {
-        publicKeyValues.msaId = record.event.data.msaId.toString();
-        publicKeyValues.newPublicKey = record.event.data.key.toString();
-        publicKeyValues.debugMsg = `Public Key: ${publicKeyValues.newPublicKey} Added for msaId: ${publicKeyValues.msaId}`;
-      }
-    });
+    // Grab the event data
+    if (event && this.api.events.msa.PublicKeyAdded.is(event)) {
+      publicKeyValues.msaId = event.data.msaId.toString();
+      publicKeyValues.newPublicKey = event.data.key.toString();
+      publicKeyValues.debugMsg = `Public Key: ${publicKeyValues.newPublicKey} Added for msaId: ${publicKeyValues.msaId}`;
+    }
 
     return publicKeyValues as PublicKeyValues;
-  };
+  }
 }

--- a/libs/common/src/blockchain/extrinsic.ts
+++ b/libs/common/src/blockchain/extrinsic.ts
@@ -1,81 +1,23 @@
-/**
- * These helpers return a map of events, some of which contain useful data, some of which don't.
- * Extrinsics that "create" records typically contain an ID of the entity they created, and this
- * would be a useful value to return. However, this data seems to be nested inside an array of arrays.
- *
- * Ex: schemaId = events["schemas.SchemaCreated"][<arbitrary_index>]
- *
- * To get the value associated with an event key, we would need to query inside that nested array with
- * a set of arbitrary indices. Should an object at any level of that querying be undefined, the helper
- * will throw an unchecked exception.
- *
- * To get type checking and cast a returned event as a specific event type, you can utilize TypeScripts
- * type guard functionality like so:
- *
- *      const msaCreatedEvent = events.defaultEvent;
- *      if (this.api.events.msa.MsaCreated.is(msaCreatedEvent)) {
- *          msaId = msaCreatedEvent.data.msaId;
- *      }
- *
- * Normally, I'd say the best experience is for the helper to return both the ID of the created entity
- * along with a map of emitted events. But in this case, returning that value will increase the complexity
- * of each helper, since each would have to check for undefined values at every lookup. So, this may be
- * a rare case when it is best to simply return the map of emitted events and trust the user to look them
- * up in the test.
- */
-
-import { ApiRx } from '@polkadot/api';
+import { ApiPromise } from '@polkadot/api';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { Call, Event, EventRecord, Hash } from '@polkadot/types/interfaces';
-import { IsEvent } from '@polkadot/types/metadata/decorate/types';
-import { Codec, ISubmittableResult } from '@polkadot/types/types';
-import { firstValueFrom } from 'rxjs';
+import { Hash } from '@polkadot/types/interfaces';
+import { ISubmittableResult } from '@polkadot/types/types';
 import { KeyringPair } from '@polkadot/keyring/types';
 
-export type EventMap = { [key: string]: Event };
+export class Extrinsic<T extends ISubmittableResult = ISubmittableResult> {
+  public readonly extrinsic: SubmittableExtrinsic<'promise', T>;
 
-function eventKey(event: Event): string {
-  return `${event.section}.${event.method}`;
-}
-
-export type ParsedEventResult = [any, EventMap];
-
-export class Extrinsic<T extends ISubmittableResult = ISubmittableResult, C extends Codec[] = Codec[], N = unknown> {
-  private event?: IsEvent<C, N>;
-
-  private extrinsic: SubmittableExtrinsic<'rxjs', T>;
-
-  // private call: Call;
   private keys: KeyringPair;
 
-  public api: ApiRx;
+  public api: ApiPromise;
 
-  constructor(api: ApiRx, extrinsic: SubmittableExtrinsic<'rxjs', T>, keys: KeyringPair, targetEvent?: IsEvent<C, N>) {
+  constructor(api: ApiPromise, extrinsic: SubmittableExtrinsic<'promise', T>, keys: KeyringPair) {
     this.extrinsic = extrinsic;
     this.keys = keys;
-    this.event = targetEvent;
     this.api = api;
   }
 
-  public get targetEvent() {
-    return this.event;
-  }
-
-  public async signAndSend(nonce?: number): Promise<[Hash, EventMap]> {
-    const { status, events, txHash } = await firstValueFrom(this.extrinsic.signAndSend(this.keys, { nonce }));
-    if (status.isFinalized || status.isInBlock) {
-      const eventMap: EventMap = {};
-      events.forEach((record: EventRecord) => {
-        const { event } = record;
-        eventMap[eventKey(event)] = event;
-      });
-      return [txHash, eventMap];
-    }
-    return [txHash, {}];
-  }
-
-  public getCall(): Call {
-    const call = this.api.createType('Call', this.extrinsic);
-    return call;
+  public async signAndSend(nonce?: number): Promise<Hash> {
+    return this.extrinsic.signAndSend(this.keys, { nonce });
   }
 }

--- a/libs/common/src/interfaces/tx-status.interface.ts
+++ b/libs/common/src/interfaces/tx-status.interface.ts
@@ -1,0 +1,10 @@
+import { TxMonitorJob } from '#lib/types/dtos/transaction.request.dto';
+
+export interface ITxStatus extends Pick<TxMonitorJob, 'providerId' | 'referenceId' | 'txHash' | 'type'> {
+  successEvent: {
+    section: string;
+    method: string;
+  };
+  birth: number;
+  death: number;
+}

--- a/libs/common/src/types/dtos/transaction.request.dto.ts
+++ b/libs/common/src/types/dtos/transaction.request.dto.ts
@@ -1,4 +1,5 @@
-import { BlockHash, Hash } from '@polkadot/types/interfaces';
+import { BlockHash } from '@polkadot/types/interfaces';
+import { HexString } from '@polkadot/util/types';
 import { PublishHandleRequest } from './handles.request.dto';
 import { PublishSIWFSignupRequest } from './wallet.login.request.dto';
 import { PublishKeysRequest } from './keys.request.dto';
@@ -11,8 +12,8 @@ export type TransactionData<RequestType = PublishHandleRequest | PublishSIWFSign
 
 export type TxMonitorJob = TransactionData & {
   id: string;
-  txHash: Hash;
-  epoch: string;
+  txHash: HexString;
+  epoch: number;
   lastFinalizedBlockHash: BlockHash;
 };
 

--- a/libs/common/src/utils/blockchain-scanner.service.spec.ts
+++ b/libs/common/src/utils/blockchain-scanner.service.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Injectable, Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { BlockHash } from '@polkadot/types/interfaces';
+import { BlockchainService } from '#lib/blockchain/blockchain.service';
+import { DEFAULT_REDIS_NAMESPACE, getRedisToken, InjectRedis } from '@liaoliaots/nestjs-redis';
+import { Redis } from 'ioredis';
+import { BlockchainScannerService } from './blockchain-scanner.service';
+
+const mockProcessBlock = jest.fn();
+
+const mockRedis = {
+  provide: getRedisToken(DEFAULT_REDIS_NAMESPACE),
+  useValue: { get: jest.fn(), set: jest.fn() },
+};
+const mockBlockchainService = {
+  provide: BlockchainService,
+  useValue: {
+    getBlockHash: (blockNumber: number) =>
+      blockNumber > 1
+        ? {
+            some: () => true,
+            isEmpty: true,
+          }
+        : {
+            some: () => true,
+            isEmpty: false,
+          },
+  },
+};
+
+@Injectable()
+class ScannerService extends BlockchainScannerService {
+  constructor(@InjectRedis() redis: Redis, blockchainService: BlockchainService) {
+    super(redis, blockchainService, new Logger('ScannerService'));
+  }
+  // eslint-disable-next-line
+  protected processCurrentBlock(currentBlockHash: BlockHash, currentBlockNumber: number): Promise<void> {
+    mockProcessBlock(currentBlockHash, currentBlockNumber);
+    return Promise.resolve();
+  }
+}
+
+const setupService = async (): Promise<ScannerService> => {
+  jest.resetModules();
+  const moduleRef = await Test.createTestingModule({
+    providers: [mockRedis, Logger, mockBlockchainService, ScannerService],
+  }).compile();
+  return moduleRef.get<ScannerService>(ScannerService);
+};
+
+describe('BlockchainScannerService', () => {
+  let service: ScannerService;
+
+  beforeEach(async () => {
+    service = await setupService();
+  });
+
+  describe('#scan', () => {
+    it('Should call processCurrentBlock', async () => {
+      await service.scan();
+      expect(mockProcessBlock).toHaveBeenCalledWith(expect.anything(), 1);
+    });
+  });
+});

--- a/libs/common/src/utils/blockchain-scanner.service.ts
+++ b/libs/common/src/utils/blockchain-scanner.service.ts
@@ -1,0 +1,92 @@
+import '@frequency-chain/api-augment';
+import { Logger } from '@nestjs/common';
+import { BlockHash } from '@polkadot/types/interfaces';
+import { BlockchainService } from '#lib/blockchain/blockchain.service';
+import Redis from 'ioredis';
+
+export const LAST_SEEN_BLOCK_NUMBER_KEY = 'lastSeenBlockNumber';
+
+export abstract class BlockchainScannerService {
+  protected scanInProgress = false;
+
+  private readonly lastSeenBlockNumberKey: string;
+
+  constructor(
+    protected cacheManager: Redis,
+    protected readonly blockchainService: BlockchainService,
+    protected readonly logger: Logger,
+  ) {
+    this.lastSeenBlockNumberKey = `${this.constructor.name}:${LAST_SEEN_BLOCK_NUMBER_KEY}`;
+  }
+
+  public async scan(): Promise<void> {
+    if (this.scanInProgress) {
+      this.logger.verbose('Scheduled blockchain scan skipped due to previous scan still in progress');
+      return;
+    }
+
+    // Only scan blocks if initial conditions met
+    if (!(await this.checkInitialScanParameters())) {
+      this.logger.verbose('Skipping blockchain scan--initial conditions not met');
+      return;
+    }
+
+    try {
+      this.scanInProgress = true;
+      let currentBlockNumber: number;
+      let currentBlockHash: BlockHash;
+
+      const lastSeenBlockNumber = await this.getLastSeenBlockNumber();
+      currentBlockNumber = lastSeenBlockNumber + 1;
+      currentBlockHash = await this.blockchainService.getBlockHash(currentBlockNumber);
+
+      if (!currentBlockHash.some((byte) => byte !== 0)) {
+        this.scanInProgress = false;
+        return;
+      }
+      this.logger.verbose(`Starting scan from block #${currentBlockNumber}`);
+
+      // eslint-disable-next-line no-await-in-loop
+      while (!currentBlockHash.isEmpty && !!(await this.checkScanParameters())) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.processCurrentBlock(currentBlockHash, currentBlockNumber);
+        // eslint-disable-next-line no-await-in-loop
+        await this.setLastSeenBlockNumber(currentBlockNumber);
+
+        // Move to the next block
+        currentBlockNumber += 1;
+        // eslint-disable-next-line no-await-in-loop
+        currentBlockHash = await this.blockchainService.getBlockHash(currentBlockNumber);
+      }
+
+      if (currentBlockHash.isEmpty) {
+        this.logger.verbose(`Scan reached end-of-chain at block ${currentBlockNumber - 1}`);
+      }
+    } catch (e) {
+      this.logger.error(JSON.stringify(e));
+      throw e;
+    } finally {
+      this.scanInProgress = false;
+    }
+  }
+
+  public async getLastSeenBlockNumber(): Promise<number> {
+    return Number((await this.cacheManager.get(this.lastSeenBlockNumberKey)) ?? 0);
+  }
+
+  protected async setLastSeenBlockNumber(b: number): Promise<void> {
+    await this.cacheManager.set(this.lastSeenBlockNumberKey, b);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  protected checkInitialScanParameters(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  protected checkScanParameters(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  protected abstract processCurrentBlock(currentBlockHash: BlockHash, currentBlockNumber: number): Promise<void>;
+}

--- a/libs/common/src/utils/redis.ts
+++ b/libs/common/src/utils/redis.ts
@@ -31,6 +31,11 @@ export namespace RedisUtils {
   export function getNonceKey(suffix: string) {
     return `${CHAIN_NONCE_KEY}:${suffix}`;
   }
+
+  /**
+   * Hash set key containing ITxStatus values for submitted chain transactions we are watching for completion
+   */
+  export const TXN_WATCH_LIST_KEY = 'txnWatchList';
 }
 
 export function redisEventsToEventEmitter(client: RedisClient, eventEmitter: EventEmitter2) {


### PR DESCRIPTION
 # Description
* Instead of adding submitted extrinsics to a monitoring queue to be checked individually, do the following:
    * For each submitted extrinsic, add a tracking entry to a Redis hash set
    * On an interval, scan the chain for any completed transactions in the hash set
    * Fast-forward chain scan to the earliest block any pending extrinsic was submitted; if no transactions pending, idle
* Fix NestJS modules declaring redundant providers from imported modules, which was causing multiple instantiation of classes which should be singleton NestJS-injected instances
* Fix the following bug: when a block was found to contain a pending transaction of interest, all the events in the block were scanned for completion of the target transaction, irrespective of whether the event belonged to the target extrinsic, or a different extrinsic in the block