### PR TITLE
fix: inverted check for finalized block

### DIFF
--- a/libs/common/src/utils/blockchain-scanner.service.ts
+++ b/libs/common/src/utils/blockchain-scanner.service.ts
@@ -106,7 +106,7 @@ export abstract class BlockchainScannerService {
     let okToScan = true;
     if (this.scanParameters?.onlyFinalized) {
       const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
-      okToScan = blockNumber > lastFinalizedBlockNumber;
+      okToScan = blockNumber <= lastFinalizedBlockNumber;
     }
 
     return okToScan;


### PR DESCRIPTION
This PR fixes an incorrect `if` check for finalized blocks