### PR TITLE
bug: Refactor interval for scanning completed transactions

### DIFF
--- a/apps/worker/src/transaction_notifier/notifier.service.ts
+++ b/apps/worker/src/transaction_notifier/notifier.service.ts
@@ -33,7 +33,7 @@ export class TxnNotifierService
     }
     this.schedulerRegistry.addInterval(
       this.intervalName,
-      setInterval(() => this.scan(), BlockchainConstants.SECONDS_PER_BLOCK * MILLISECONDS_PER_SECOND),
+      setInterval(() => this.scan(), MILLISECONDS_PER_SECOND),
     );
   }
 


### PR DESCRIPTION
Change the Blockchain scanner interval to speed up account webhook response, so the front end does not timeout on account creation.